### PR TITLE
- init root screen for home, fav, category and profile tab

### DIFF
--- a/lib/core/di/di.config.dart
+++ b/lib/core/di/di.config.dart
@@ -30,6 +30,7 @@ import '../../features/authentication/domain/use%20case/sign_up_use_case.dart'
     as _i642;
 import '../../features/authentication/ui/cubit/authentication_view_model.dart'
     as _i239;
+import '../../features/root/ui/cubit/root_view_model.dart' as _i21;
 import '../api%20manager/api_manager.dart' as _i949;
 import '../network/network_info.dart' as _i932;
 
@@ -40,6 +41,7 @@ extension GetItInjectableX on _i174.GetIt {
     _i526.EnvironmentFilter? environmentFilter,
   }) {
     final gh = _i526.GetItHelper(this, environment, environmentFilter);
+    gh.factory<_i21.RootViewModel>(() => _i21.RootViewModel());
     gh.singleton<_i949.ApiManager>(() => _i949.ApiManager());
     gh.lazySingleton<_i932.NetworkInfo>(() => _i932.NetworkInfoImpl());
     gh.lazySingleton<_i638.SignInDataSource>(

--- a/lib/core/routing/app_route_names.dart
+++ b/lib/core/routing/app_route_names.dart
@@ -1,8 +1,5 @@
-// import 'package:ecommerce/presentation/authentication/Features/auth/register.dart';
-// import 'package:ecommerce/presentation/authentication/Features/auth/login.dart';
-// import 'package:ecommerce/presentation/root/ui/root.dart';
 import 'package:ecommerce/features/authentication/ui/authentication.dart';
-import 'package:ecommerce/features/authentication/ui/sign%20up/sign_up.dart';
+import 'package:ecommerce/features/root/ui/root.dart';
 import 'package:flutter/cupertino.dart';
 
 import 'app_routes.dart';
@@ -11,6 +8,7 @@ class Routes {
   static Map<String, Widget Function(BuildContext)> routes = {
     // Define your routes here
     AppRoutes.authenticationRoute: (context) => const Authentication(),
+    AppRoutes.root: (context) => Root(),
 
     // AppRoutes.loginRoute: (context) => const Login(),
     // AppRoutes.registerRoute: (context) => SignUp(),

--- a/lib/core/routing/app_routes.dart
+++ b/lib/core/routing/app_routes.dart
@@ -1,5 +1,5 @@
 class AppRoutes {
-  static const String root = "home tab";
+  static const String root = "root";
   static const String productRoute = "productDetails";
   static const String cartRoute = "cart";
   static const String authenticationRoute = "Authentication";

--- a/lib/features/root/ui/cubit/root_states.dart
+++ b/lib/features/root/ui/cubit/root_states.dart
@@ -1,0 +1,5 @@
+abstract class RootStates {}
+
+class RootInitialState extends RootStates {}
+
+class RootChangeSelectedIndexState extends RootStates {}

--- a/lib/features/root/ui/cubit/root_view_model.dart
+++ b/lib/features/root/ui/cubit/root_view_model.dart
@@ -1,0 +1,33 @@
+import 'package:ecommerce/features/root/ui/cubit/root_states.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+
+@injectable
+class RootViewModel extends Cubit<RootStates> {
+  RootViewModel() : super(RootInitialState());
+
+  //todo: hold data - handle logic
+  int selectedIndex = 0;
+  List<Widget> bodyList = const [
+    Scaffold(
+      body: Center(child: Text('Home')),
+    ),
+    Scaffold(
+      body: Center(child: Text('Products')),
+    ),
+    Scaffold(
+      body: Center(child: Text('Favorites')),
+    ),
+    Scaffold(
+      body: Center(child: Text('User')),
+    ),
+  ];
+
+  void bottomNavOnTap(int index) {
+    selectedIndex = index;
+    emit(RootChangeSelectedIndexState());
+  }
+}

--- a/lib/features/root/ui/root.dart
+++ b/lib/features/root/ui/root.dart
@@ -1,0 +1,171 @@
+import 'package:ecommerce/core/di/di.dart';
+import 'package:ecommerce/core/helpers/app_assets.dart';
+import 'package:ecommerce/core/utils/app_colors.dart';
+import 'package:ecommerce/core/utils/app_styles.dart';
+import 'package:ecommerce/features/root/ui/cubit/root_states.dart';
+import 'package:ecommerce/features/root/ui/cubit/root_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class Root extends StatelessWidget {
+  RootViewModel viewModel = getIt<RootViewModel>();
+
+  Root({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<RootViewModel, RootStates>(
+      bloc: viewModel,
+      builder: (context, state) {
+        return Scaffold(
+          appBar: _buildAppBar(viewModel.selectedIndex, context),
+          body: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 10.w),
+            child: viewModel.bodyList[viewModel.selectedIndex],
+          ),
+          bottomNavigationBar: ClipRRect(
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(16.r),
+              topRight: Radius.circular(16.r),
+            ),
+            child: Container(
+              height: 90.h,
+              color: AppColors.primaryColor,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _buildNavItem(
+                    0,
+                    AppAssets.unSelectedHomeIcon,
+                    AppAssets.selectedHomeIcon,
+                  ),
+                  _buildNavItem(
+                    1,
+                    AppAssets.unSelectedCategoryIcon,
+                    AppAssets.selectedCategoryIcon,
+                  ),
+                  _buildNavItem(
+                    2,
+                    AppAssets.unSelectedFavouriteIcon,
+                    AppAssets.selectedFavouriteIcon,
+                  ),
+                  _buildNavItem(
+                    3,
+                    AppAssets.unSelectedAccountIcon,
+                    AppAssets.selectedAccountIcon,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildNavItem(int index, String unselectedIcon, String selectedIcon) {
+    final isSelected = viewModel.selectedIndex == index;
+    return GestureDetector(
+      onTap: () => viewModel.bottomNavOnTap(index),
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 10.h),
+        child: CircleAvatar(
+          radius: 25.r,
+          backgroundColor: isSelected
+              ? AppColors.whiteColor
+              : Colors.transparent,
+          child: Image.asset(
+            isSelected ? selectedIcon : unselectedIcon,
+            width: 24.w,
+            height: 24.h,
+          ),
+        ),
+      ),
+    );
+  }
+
+  OutlineInputBorder _buildCustomBorder() {
+    return OutlineInputBorder(
+      borderSide: const BorderSide(color: AppColors.primaryColor, width: 1),
+      borderRadius: BorderRadius.circular(50.r),
+    );
+  }
+
+  PreferredSizeWidget _buildAppBar(int index, BuildContext context) {
+    return AppBar(
+      surfaceTintColor: AppColors.transparentColor,
+      elevation: 0,
+      toolbarHeight: index != 3 ? 120.h : kToolbarHeight,
+      leadingWidth: double.infinity,
+      leading: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 10.w, vertical: 10.h),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: EdgeInsets.only(bottom: 10.h),
+              child: Image.asset(
+                AppAssets.routeLogo,
+                width: 66.w,
+                height: 22.h,
+              ),
+            ),
+            Visibility(
+              visible: index != 3,
+              child: Expanded(
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        style: AppStyles.regular14Text,
+                        cursorColor: AppColors.primaryColor,
+                        onTap: () {
+                          //todo: implement search logic
+                        },
+                        decoration: InputDecoration(
+                          border: _buildCustomBorder(),
+                          enabledBorder: _buildCustomBorder(),
+                          focusedBorder: _buildCustomBorder(),
+                          contentPadding: EdgeInsets.all(16.h),
+                          hintStyle: AppStyles.light14SearchHint,
+                          hintText: "what do you search for?",
+                          prefixIcon: Icon(
+                            Icons.search,
+                            size: 30.sp,
+                            color: AppColors.primaryColor.withOpacity(0.75),
+                          ),
+                        ),
+                      ),
+                    ),
+                    InkWell(
+                      onTap: () {
+                        // Navigator.of(context).pushNamed(AppRoutes.cartRoute);
+                      },
+                      child: Badge(
+                        alignment: AlignmentDirectional.topStart,
+                        backgroundColor: AppColors.greenColor,
+                        label: Text(
+                          2.toString(),
+                          style: AppStyles.regular12Text.copyWith(
+                            color: AppColors.whiteColor,
+                          ),
+                        ),
+                        child: ImageIcon(
+                          const AssetImage(AppAssets.shoppingCart),
+                          size: 35.sp,
+                          color: AppColors.primaryColor,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
         debugShowCheckedModeBanner: false,
         theme: AppTheme.lightTheme,
         routes: Routes.routes,
-        initialRoute: AppRoutes.authenticationRoute,
+        initialRoute: AppRoutes.root,
         // home: const Register(),
       ),
     );


### PR DESCRIPTION
**- added new route name for the root screen
- initialize the root with its state management handled for navigating between tabs 
- full initialization of root screen completed**
<div style="display: flex; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/f2a5dfcb-dcc1-4d9a-a292-06917d2e1aa9" alt="Screenshot 1" width="200" />
  <img src="https://github.com/user-attachments/assets/1e894040-2e0f-41ed-9ded-c410cf94b6dd" alt="Screenshot 2" width="200" />
  <img src="https://github.com/user-attachments/assets/42773426-b7fc-4aac-b936-6afdfd1c6d96" alt="Screenshot 3" width="200" />
  <img src="https://github.com/user-attachments/assets/1e6a5ad6-7230-401c-bdb5-50c8dd5ee37e" alt="Screenshot 4" width="200" />
</div>
